### PR TITLE
When copying an environment add the text "Copy of " before the newly copied environment.

### DIFF
--- a/src/actions/EnvActions.js
+++ b/src/actions/EnvActions.js
@@ -12,6 +12,7 @@ export const copyEnvToAccount = (params, state) => {
   var newId = copiedEnv.profileId = generateId();
   copiedEnv.id = newId;
   copiedEnv.profileId = newId;
+  copiedEnv.name = 'Copy of ' + copiedEnv.name;
 
   return saveInBatches(state.user.apikey, contextType, contextId, [{...copiedEnv, type: "dataProfile"}]);
 


### PR DESCRIPTION
When copying an environment add the text "Copy of " before the newly copied environment.

This allows to distinguish between original and the copy when the source and destination is the same.